### PR TITLE
Check if result of get is not nil so that nil is not returned for false.

### DIFF
--- a/src/reagent/session.cljs
+++ b/src/reagent/session.cljs
@@ -13,7 +13,8 @@
   "Get the key's value from the session, returns nil if it doesn't exist."
   [k & [default]]
   (let [temp-a (cursor [k])]
-    (or @temp-a default)))
+    (if-not (nil? @temp-a)
+      @temp-a default)))
 
 (defn put! [k v]
   (clojure.core/swap! state assoc k v))


### PR DESCRIPTION
I had a few variables in my state that were false and I needed false to be returned, not nil.  This change checks if the contents of the cursor is empty vs falsy.