### PR TITLE
changed link in currency-format comment

### DIFF
--- a/src/reagent/format.cljs
+++ b/src/reagent/format.cljs
@@ -49,7 +49,7 @@
    to change locale set goog.i18n.NumberFormatSymbols eg:
    (set! goog.i18n.NumberFormatSymbols goog.i18n.NumberFormatSymbols_it_IT)
    see here for supported locales
-   https://github.com/google/closure-library/blob/master/closure/goog/i18n/compactnumberformatsymbols.js
+   https://github.com/google/closure-library/blob/master/closure/goog/i18n/numberformatsymbols.js
   "
   [n]
   (.format (goog.i18n.NumberFormat. (.-CURRENCY goog.i18n.NumberFormat.Format)) n))


### PR DESCRIPTION
Link before was for the page delineating "compact number format symbols", but the rest of this comment is all about "number format symbols". The link now reflects that.