### PR TITLE
Support remove cookie path & domain args

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ specified by the vector ks and then removes it from the session.</pre></div></di
 the current value and args.</pre></div></div><div class="public anchor" id="var-update.21"><h3>update!</h3><div class="usage"><code>(update! k f &amp; args)</code></div><div class="doc"><pre class="plaintext">Updates a value in session where k is a key and f
 is the function that takes the old value along with any
 supplied args and return the new value. If key is not
-present it will be added.</pre></div></div><div class="public anchor" id="var-update-in.21"><h3>update-in!</h3><div class="usage"><code>(update-in! ks f &amp; args)</code></div><div class="doc"><pre class="plaintext">'Updates a value in the session, where ks is a
+present it will be added.</pre></div></div><div class="public anchor" id="var-update-in.21"><h3>update-in!</h3><div class="usage"><code>(update-in! ks f &amp; args)</code></div><div class="doc"><pre class="plaintext">Updates a value in the session, where ks is a
 sequence of keys and f is a function that will
 take the old value along with any supplied args and return
 the new value. If any levels do not exist, hash-maps

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library provides a number of convenience helpers for use with Reagent.
 </pre></div></div><div class="public anchor" id="var-get-raw"><h3>get-raw</h3><div class="usage"><code>(get-raw k &amp; [default])</code></div><div class="doc"><pre class="plaintext">gets the value at the key (as string), optional default when value is not found
 </pre></div></div><div class="public anchor" id="var-keys"><h3>keys</h3><div class="usage"><code>(keys)</code></div><div class="doc"><pre class="plaintext">returns all the keys for the cookies
 </pre></div></div><div class="public anchor" id="var-raw-vals"><h3>raw-vals</h3><div class="usage"><code>(raw-vals)</code></div><div class="doc"><pre class="plaintext">returns cookie values (as strings)
-</pre></div></div><div class="public anchor" id="var-remove.21"><h3>remove!</h3><div class="usage"><code>(remove! k)</code></div><div class="doc"><pre class="plaintext">removes a cookie
+</pre></div></div><div class="public anchor" id="var-remove.21"><h3>remove!</h3><div class="usage"><code>(remove! k)</code><code>(remove! k path domain)</code></div><div class="doc"><pre class="plaintext">removes a cookie, optionally for a specific path and/or domain
 </pre></div></div><div class="public anchor" id="var-set.21"><h3>set!</h3><div class="usage"><code>(set! k content &amp; [{:keys [max-age path domain secure? raw?]} :as opts])</code></div><div class="doc"><pre class="plaintext">sets a cookie, the max-age for session cookie
 following optional parameters may be passed in as a map:
 :max-age - defaults to -1

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reagent-utils "0.3.0"
+(defproject reagent-utils "0.4.0-SNAPSHOT"
   :description "various utility functions for Reagent based projects"
   :url "https://github.com/reagent-project/reagent-utils"
   :license {:name "Eclipse Public License"

--- a/src/reagent/cookies.cljs
+++ b/src/reagent/cookies.cljs
@@ -77,9 +77,11 @@
   (.isEmpty goog.net.cookies))
 
 (defn remove!
-  "removes a cookie"
-  [k]
-  (.remove goog.net.cookies (name k)))
+  "removes a cookie, optionally for a specific path and/or domain"
+  ([k]
+   (.remove goog.net.cookies (name k)))
+  ([k path domain]
+   (.remove goog.net.cookies (name k) path domain)))
 
 (defn clear!
   "removes all cookies"

--- a/src/reagent/session.cljs
+++ b/src/reagent/session.cljs
@@ -78,7 +78,7 @@
     #(apply (partial update % k f) args)))
   
 (defn update-in!
-  "'Updates a value in the session, where ks is a
+  "Updates a value in the session, where ks is a
    sequence of keys and f is a function that will
    take the old value along with any supplied args and return
    the new value. If any levels do not exist, hash-maps


### PR DESCRIPTION
This is related to #12: if we `set!` with a custom/wildcard domain we need to be able to specify the same domain for `remove!`, otherwise the cookie doesn't get removed.

This adds a `remove!` arity that matches `goog.net.cookies.remove()` args [here](https://github.com/google/closure-library/blob/39aa374bbdea59f22a172896eba7f9bfd50c368c/closure/goog/net/cookies.js#L211).