### PR TITLE
Remove unused requires of Google Closure classes

### DIFF
--- a/src/reagent/format.cljs
+++ b/src/reagent/format.cljs
@@ -5,8 +5,6 @@
     [goog.string :as gstring]
     [goog.string.format]
     [goog.i18n.DateTimeFormat :as dtf]
-    [goog.i18n.NumberFormat :as nf]
-    [goog.i18n.NumberFormatSymbols :as symbols]
     [goog.crypt :as crypt]
     [goog.crypt.Md5 :as Md5]
     [goog.crypt.Sha1 :as Sha1]


### PR DESCRIPTION
Everything in the Google Closure Library is available without any explicit require or import as long as the names are fully qualified with `goog....`. That is the form we use here, so no require or import is necessary.

Classes like NumberFormat and DateTimeFormat could be made available without the `goog.` prefix or be renamed with an `import`, but qualifying them fully works as well.