### PR TITLE
Support new GCL and same-site attribute

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,16 @@
   :codox {:language :clojurescript
           :exclude  clojure.string}
 
-  :profiles {:dev
-             {:dependencies [[org.clojure/clojure "1.10.0"]
-                             [org.clojure/clojurescript "1.10.439"]
-                             [reagent "0.8.1"]]
-              :plugins      [[lein-doo "0.1.7"]]}}
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.10.0"]
+                                  [org.clojure/clojurescript "1.10.439"]
+                                  [reagent "0.8.1"]]
+                   :plugins      [[lein-doo "0.1.7"]]}
+             :gcl-v20210505 [:dev {:dependencies [[org.clojure/clojurescript "1.10.866" :exclusions [com.google.javascript/closure-compiler-unshaded
+                                                                                                     org.clojure/google-closure-library
+                                                                                                     org.clojure/google-closure-library-third-party]]
+                                                  [com.google.javascript/closure-compiler-unshaded "v20210505"]
+                                                  [org.clojure/google-closure-library "0.0-20201211-3e6c510d"]
+                                                  [org.clojure/google-closure-library-third-party "0.0-20201211-3e6c510d"]]}]}
 
   :cljsbuild {:builds
               {:test

--- a/src/reagent/cookies.cljs
+++ b/src/reagent/cookies.cljs
@@ -23,6 +23,7 @@
    :domain - domain of the cookie, when null the browser will use the full request host name
    :secure? - boolean specifying whether the cookie should only be sent over a secure channel
    :raw? - boolean specifying whether content should be stored raw, or as EDN
+   :same-site - A keyword of either :strict, :lax, or :none (defaults to :none). Only supported when `supports-same-site?` is true
   "
   [k content & [{:keys [max-age path domain secure? raw? same-site] :as opts}]]
   (let [k (name k)

--- a/test/reagent/cookies_test.cljs
+++ b/test/reagent/cookies_test.cljs
@@ -1,6 +1,22 @@
 (ns reagent.cookies-test
-  (:require [cljs.test :refer-macros [deftest testing is]]
-            [reagent.cookies :as cookies]))
+  (:require
+    [cljs.test :refer-macros [deftest testing is use-fixtures]]
+    [clojure.string :as str]
+    [reagent.cookies :as cookies]))
+
+(defn stub-cookies [f]
+  (let [old (.getInstance goog.net.Cookies)
+        stub (new goog.net.Cookies nil)]
+    (set! goog.net.cookies stub) ;NOTE the google closure library marks this method as deprecated
+    (f)
+    (set! goog.net.cookies old)))
+
+(defn- raw-cookie-val []
+  (-> goog.net.cookies
+      (.-document_)
+      (.-cookie)))
+
+(use-fixtures :once stub-cookies)
 
 (deftest reading-cookie-values
 
@@ -13,7 +29,7 @@
 
   (testing "get can't read invalid edn from cookie"
     (.set goog.net.cookies "some-cookie" "123abc")
-    (is (thrown-with-msg? js/Error #"Invalid number format" (cookies/get :some-cookie))))
+    (is (thrown-with-msg? js/Error #"Invalid number: 123abc" (cookies/get :some-cookie))))
 
   (testing "get raw provides default value if cookie not set"
     (is (= (cookies/get-raw :non-existent "default-val") "default-val")))
@@ -32,4 +48,31 @@
 
   (testing "get reads raw vals from cookie"
     (.set goog.net.cookies "some-cookie" "123abc")
-    (is (= (cookies/raw-vals) ["123abc"]))))
+    (is (= (cookies/raw-vals) ["123abc"])))
+
+  (testing "can specify options"
+
+    (testing "path"
+      (let [path "reagent-utils/cookie/path"]
+        (cookies/set! :path-cookie "path-cookie" {:path path})
+        (is (= (cookies/get :path-cookie) "path-cookie"))
+        (is (str/includes? (raw-cookie-val) (str "path=" path)))))
+
+    (testing "domain"
+      (let [domain "http://reagent-utils.cookie.local"]
+        (cookies/set! :domain-cookie "domain-cookie" {:domain domain})
+        (is (= (cookies/get :domain-cookie) "domain-cookie"))
+        (is (str/includes? (raw-cookie-val) (str "domain=" domain)))))
+
+    (testing "max-age"
+      (cookies/set! :max-age-cookie "max-age" {:max-age 200})
+      (is (= (cookies/get :max-age-cookie) "max-age"))
+      (is (str/includes? (raw-cookie-val) "\"max-age\";expires")))
+
+    (when (cookies/supports-same-site?)
+      (testing "same-site"
+        (doseq [opt [:lax :strict :none]]
+          (let [v (name opt)]
+            (cookies/set! :same-site-cookie v {:same-site opt})
+            (is (= (cookies/get :same-site-cookie) v))
+            (is (str/includes? (raw-cookie-val) (str "samesite=" v)))))))))

--- a/test/reagent/cookies_test.cljs
+++ b/test/reagent/cookies_test.cljs
@@ -4,7 +4,7 @@
     [clojure.string :as str]
     [reagent.cookies :as cookies]))
 
-(defn stub-cookies [f]
+(defn- stub-cookies [f]
   (let [old (.getInstance goog.net.Cookies)
         stub (new goog.net.Cookies nil)]
     (set! goog.net.cookies stub) ;NOTE the google closure library marks this method as deprecated


### PR DESCRIPTION
Should resolve #17 and #16.

* Have run tests for `chrome`, `firefox` and `safari` on my MacBook. Not sure what other browsers require testing.
  * `lein with-profile +dev doo safari test`; and
  * `lein with-profile +gcl-v20210505 doo safari test`
* Adds support for new GCL libraries, while preserving older ones by means for checking [JavaScript Function Length](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/length)
* Added a fixture to set the global variable and revert after tests. This grants access to the raw cookie value, which would otherwise be unavailable.
* Added new `reagent.cookies/supports-same-site?` predicate to aid in testing