### PR TITLE
Avoid using deleted goog.net.cookies; fixes #21

### DIFF
--- a/src/reagent/cookies.cljs
+++ b/src/reagent/cookies.cljs
@@ -2,15 +2,16 @@
   (:refer-clojure :exclude [count get keys vals empty? reset!])
   (:require
     [cljs.reader :as reader]
-    [goog.net.cookies]
     [goog.net.Cookies :refer [SetOptions]]))
+
+(defonce ^:dynamic *cookies* (or goog.net.cookies (.getInstance goog.net.Cookies)))
 
 ;Pre Google Closure library v20200204
 (defonce ^:private legacy-setter?
-  (delay (= 6 (.-length goog.net.cookies.set))))
+  (delay (= 6 (.-length (.-set *cookies*)))))
 
 (defn supports-same-site?
-  "True if the the underlying version of `goog.net.cookies` supports the same-site attribute
+  "True if the underlying version of `goog.net.Cookies` supports the same-site attribute
    when setting cookies
   "
   []
@@ -33,13 +34,13 @@
                   (pr-str content))]
     (cond
       (not (dissoc opts :raw?))
-      (.set goog.net.cookies k content)
+      (.set *cookies* k content)
 
       @legacy-setter?
-      (.set goog.net.cookies k content (or max-age -1) path domain (boolean secure?))
+      (.set *cookies* k content (or max-age -1) path domain (boolean secure?))
 
       :else
-      (.set goog.net.cookies k content
+      (.set *cookies* k content
             (doto (SetOptions.)
               (set! -maxAge (or max-age -1))
               (set! -path path)
@@ -58,7 +59,7 @@
 
 (defn- get-value
   [k r default]
-  (or (->> (name k) (.get goog.net.cookies) r) default))
+  (or (->> (name k) (.get *cookies*) r) default))
 
 (defn get
   "gets the value at the key (as edn), optional default when value is not found"
@@ -73,46 +74,46 @@
 (defn contains-key?
   "is the key present in the cookies"
   [k]
-  (.containsKey goog.net.cookies (name k)))
+  (.containsKey *cookies* (name k)))
 
 (defn contains-val?
   "is the value present in the cookies (as string)"
   [v]
-  (.containsValue goog.net.cookies v))
+  (.containsValue *cookies* v))
 
 (defn count
   "returns the number of cookies"
   []
-  (.getCount goog.net.cookies))
+  (.getCount *cookies*))
 
 (defn keys
   "returns all the keys for the cookies"
   []
-  (map keyword (.getKeys goog.net.cookies)))
+  (map keyword (.getKeys *cookies*)))
 
 (defn vals
   "returns cookie values (as edn)"
   []
-  (map read-edn-value (.getValues goog.net.cookies)))
+  (map read-edn-value (.getValues *cookies*)))
 
 (defn raw-vals
   "returns cookie values (as strings)"
   []
-  (map read-raw-value (.getValues goog.net.cookies)))
+  (map read-raw-value (.getValues *cookies*)))
 
 (defn empty?
   "true if no cookies are set"
   []
-  (.isEmpty goog.net.cookies))
+  (.isEmpty *cookies*))
 
 (defn remove!
   "removes a cookie, optionally for a specific path and/or domain"
   ([k]
-   (.remove goog.net.cookies (name k)))
+   (.remove *cookies* (name k)))
   ([k path domain]
-   (.remove goog.net.cookies (name k) path domain)))
+   (.remove *cookies* (name k) path domain)))
 
 (defn clear!
   "removes all cookies"
   []
-  (.clear goog.net.cookies))
+  (.clear *cookies*))

--- a/test/reagent/cookies_test.cljs
+++ b/test/reagent/cookies_test.cljs
@@ -5,14 +5,11 @@
     [reagent.cookies :as cookies]))
 
 (defn- stub-cookies [f]
-  (let [old (.getInstance goog.net.Cookies)
-        stub (new goog.net.Cookies nil)]
-    (set! goog.net.cookies stub) ;NOTE the google closure library marks this method as deprecated
-    (f)
-    (set! goog.net.cookies old)))
+  (binding [cookies/*cookies* (new goog.net.Cookies nil)]
+    (f)))
 
 (defn- raw-cookie-val []
-  (-> goog.net.cookies
+  (-> cookies/*cookies*
       (.-document_)
       (.-cookie)))
 
@@ -24,11 +21,11 @@
     (is (= (cookies/get :non-existent "default-val") "default-val")))
 
   (testing "get reads edn from cookie"
-    (.set goog.net.cookies "some-cookie" "{:edn 123}")
+    (.set cookies/*cookies* "some-cookie" "{:edn 123}")
     (is (= (cookies/get :some-cookie) {:edn 123})))
 
   (testing "get can't read invalid edn from cookie"
-    (.set goog.net.cookies "some-cookie" "123abc")
+    (.set cookies/*cookies* "some-cookie" "123abc")
     (is (thrown-with-msg? js/Error #"Invalid number: 123abc" (cookies/get :some-cookie))))
 
   (testing "get raw provides default value if cookie not set"
@@ -36,18 +33,18 @@
 
   (testing "set writes raw string to cookie"
     (cookies/set! :some-cookie "123abc" {:raw? true})
-    (is (= (.get goog.net.cookies "some-cookie") "123abc")))
+    (is (= (.get cookies/*cookies* "some-cookie") "123abc")))
 
   (testing "get reads raw string from cookie"
-    (.set goog.net.cookies "some-cookie" "123abc")
+    (.set cookies/*cookies* "some-cookie" "123abc")
     (is (= (cookies/get-raw :some-cookie) "123abc")))
 
   (testing "get reads edn vals from cookie"
-    (.set goog.net.cookies "some-cookie" "{:edn 123}")
+    (.set cookies/*cookies* "some-cookie" "{:edn 123}")
     (is (= (cookies/vals) [{:edn 123}])))
 
   (testing "get reads raw vals from cookie"
-    (.set goog.net.cookies "some-cookie" "123abc")
+    (.set cookies/*cookies* "some-cookie" "123abc")
     (is (= (cookies/raw-vals) ["123abc"])))
 
   (testing "can specify options"


### PR DESCRIPTION
I've done my best to make this backwards compatible, though I cannot imagine anyone is using a version of GCL that old.