### PR TITLE
fix wrong cond: used to be always false

### DIFF
--- a/src/reagent/cookies.cljs
+++ b/src/reagent/cookies.cljs
@@ -33,7 +33,7 @@
                   (str content)
                   (pr-str content))]
     (cond
-      (not (dissoc opts :raw?))
+      (clojure.core/empty? (dissoc opts :raw?))
       (.set *cookies* k content)
 
       @legacy-setter?


### PR DESCRIPTION
```clojure
(not {}) ;=> false
```